### PR TITLE
added containerization for frontend application (#6)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - backend
   ticklist-frontend:
     image: matthaeusheer/ticklist/frontend-0.0.1
-    build: ./frontend
+    build: ./frontend/app
     ports:
       - "4200:4200"
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,0 @@
-FROM busybox
-
-CMD echo 'Hello world'

--- a/frontend/app/Dockerfile
+++ b/frontend/app/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM node:16.18-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build --prod
+
+# Package stage
+FROM nginx:1.23.2-alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY --from=build /app/dist/frontend /usr/share/nginx/html
+
+EXPOSE 4200

--- a/frontend/app/angular.json
+++ b/frontend/app/angular.json
@@ -105,5 +105,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/frontend/app/nginx.conf
+++ b/frontend/app/nginx.conf
@@ -1,0 +1,12 @@
+events{}
+http {    include /etc/nginx/mime.types;
+	server {
+		listen 80;
+        server_name localhost;
+        root /usr/share/nginx/html;
+        index index.html;
+		location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
# Overview
The Angular frontend application can now be built and served as a docker container.

# How to Use
To build and launch all services use
```
docker-compose up
```
or 
```
docker-compose up --no-build
```
in case you have your builds already.

Or to launch only the frontend container
```
docker run -p 8080:80 ticklist-frontend
```
if you have an image tagged like that available.
